### PR TITLE
Revert "Bump org.codehaus.plexus:plexus-archiver from 3.7.0 to 4.8.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -526,7 +526,7 @@
                         <dependency>
                             <groupId>org.codehaus.plexus</groupId>
                             <artifactId>plexus-archiver</artifactId>
-                            <version>4.8.0</version>
+                            <version>3.7.0</version>
                         </dependency>
                     </dependencies>
                     <configuration>


### PR DESCRIPTION
Reverts DANS-KNAW/dd-parent#4

We need to wait until maven 3.6.3 is available, because plexus-archiver 4.8.0 requires rpm-maven-plugin 2.3.0 requires maven 3.6.3